### PR TITLE
A few more OS X getxattr fixes

### DIFF
--- a/FileSystem.c
+++ b/FileSystem.c
@@ -291,7 +291,7 @@ int FileGetBinaryXAttr(char **RetStr, const char *Path, const char *Name)
 
     *RetStr=CopyStr(*RetStr, "");
 #ifdef HAVE_XATTR
-	#ifdef _APPLE_ //'cos some idiot's always got to 'think different'
+	#ifdef __APPLE__ //'cos some idiot's always got to 'think different'
     len=getxattr(Path, Name, NULL, 0, 0, 0);
 	#else
     len=getxattr(Path, Name, NULL, 0);
@@ -323,7 +323,7 @@ char *FileGetXAttr(char *RetStr, const char *Path, const char *Name)
 int FileSetBinaryXAttr(const char *Path, const char *Name, const char *Value, int Len)
 {
 #ifdef HAVE_XATTR
-	#ifdef _APPLE_
+	#ifdef __APPLE__
     return(setxattr(Path, Name, Value, Len, 0, 0, 0));
 	#else
     return(setxattr(Path, Name, Value, Len, 0));

--- a/FileSystem.c
+++ b/FileSystem.c
@@ -300,7 +300,11 @@ int FileGetBinaryXAttr(char **RetStr, const char *Path, const char *Name)
     if (len > 0)
     {
         *RetStr=SetStrLen(*RetStr,len);
+        #ifdef __APPLE__
+        getxattr(Path, Name, *RetStr, len, 0, 0);
+        #else
         getxattr(Path, Name, *RetStr, len);
+        #endif
     }
 #else
     RaiseError(0, "FileGetXAttr", "xattr support not compiled in");

--- a/FileSystem.c
+++ b/FileSystem.c
@@ -328,7 +328,7 @@ int FileSetBinaryXAttr(const char *Path, const char *Name, const char *Value, in
 {
 #ifdef HAVE_XATTR
 	#ifdef __APPLE__
-    return(setxattr(Path, Name, Value, Len, 0, 0, 0));
+    return(setxattr(Path, Name, Value, Len, 0, 0));
 	#else
     return(setxattr(Path, Name, Value, Len, 0));
 	#endif


### PR DESCRIPTION
This follows up on the fix you made for #1.

* Uses `__APPLE__` for the `#ifdef`s.
* Adds an `#ifdef` for a `getxattr` function call that got missed.
* Fixes the number of parameters to `setxattr`, which ended up with seven instead of six arguments.

Fixes #1.