### PR TITLE
Fix build for macOS

### DIFF
--- a/Entropy.c
+++ b/Entropy.c
@@ -2,6 +2,7 @@
 #include "Encodings.h"
 #include "Hash.h"
 #include <sys/utsname.h>
+#include <sys/random.h>
 
 
 #ifdef HAVE_GETENTROPY

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,9 +1,22 @@
 CC = @CC@
 AR = @AR@
+LN = ln
 VERSION = 5.37
 MAJOR=5
-LIBFILE=libUseful.so.$(VERSION)
-SONAME=libUseful.so.$(MAJOR)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	SONAME_SUFFIX = dylib
+	SONAME_VER_SUFFIX = $(MAJOR).$(SONAME_SUFFIX)
+	LIBFILE_SUFFIX = $(VERSION).$(SONAME_SUFFIX)
+	LINKER_SONAME_OPTION = -dylib_install_name
+else
+	SONAME_SUFFIX = so
+	SONAME_VER_SUFFIX = $(SONAME_SUFFIX).$(MAJOR)
+	LIBFILE_SUFFIX = $(SONAME_SUFFIX).$(VERSION)
+	LINKER_SONAME_OPTION = -soname
+endif
+LIBFILE = libUseful.$(LIBFILE_SUFFIX)
+SONAME = libUseful.$(SONAME_VER_SUFFIX)
 CFLAGS = @CFLAGS@ @SIMD_CFLAGS@ @SONAME_FLAGS@
 LDFLAGS=@LDFLAGS@
 LIBS = @LIBS@
@@ -15,13 +28,13 @@ OBJ=StrLenCache.o String.o Array.o List.o IPAddress.o Socket.o Server.o UnixSock
 
 all: $(OBJ)
 	$(CC) $(FLAGS) -shared -o $(LIBFILE) $(OBJ) $(LIBS) $(LDFLAGS)
-	-ln -s -r -f $(LIBFILE) libUseful-$(VERSION).so
-	-ln -s -r -f $(LIBFILE) libUseful-$(MAJOR).so
-	-ln -s -r -f $(LIBFILE) $(SONAME)
-	-ln -s -r -f $(LIBFILE) libUseful.so
+	-$(LN) -s -r -f $(LIBFILE) libUseful-$(VERSION).$(SONAME_SUFFIX)
+	-$(LN) -s -r -f $(LIBFILE) libUseful-$(MAJOR).$(SONAME_SUFFIX)
+	-$(LN) -s -r -f $(LIBFILE) $(SONAME)
+	-$(LN) -s -r -f $(LIBFILE) libUseful.$(SONAME_SUFFIX)
 	$(AR) rcs libUseful-$(VERSION).a $(OBJ)
-	-ln -s -r -f libUseful-$(VERSION).a libUseful-$(MAJOR).a
-	-ln -s -r -f libUseful-$(VERSION).a libUseful.a
+	-$(LN) -s -r -f libUseful-$(VERSION).a libUseful-$(MAJOR).a
+	-$(LN) -s -r -f libUseful-$(VERSION).a libUseful.a
 
 
 StrLenCache.o: StrLenCache.h StrLenCache.c
@@ -278,20 +291,20 @@ LibSettings.o: LibSettings.h LibSettings.c
 	$(CC) $(FLAGS) -c LibSettings.c
 
 clean:
-	-rm -f *.o *.so *.so.* *.a *.orig .*.swp *~
-	-rm config.log config.status 
+	-rm -f *.o *.$(SONAME_SUFFIX) *.$(SONAME_VER_SUFFIX) *.$(LIBFILE_SUFFIX) *.a *.orig .*.swp *~
+	-rm config.log config.status
 	-rm -r autom4te.cache config.cache
 	-$(MAKE) clean -C examples
 
-install: libUseful.so
-	-mkdir -p $(DESTDIR)$(prefix)/lib 
-	cp -P *.so *.so.* *.a $(DESTDIR)$(prefix)/lib  
+install: libUseful.$(SONAME_SUFFIX)
+	-mkdir -p $(DESTDIR)$(prefix)/lib
+	cp -P *.$(SONAME_SUFFIX) *.$(SONAME_VER_SUFFIX) *.$(LIBFILE_SUFFIX) *.a $(DESTDIR)$(prefix)/lib
 	-mkdir -p $(DESTDIR)$(prefix)/include/libUseful-$(VERSION)
 	cp *.h $(DESTDIR)$(prefix)/include/libUseful-$(VERSION)
-	-ln -s -r -f $(DESTDIR)$(prefix)/include/libUseful-$(VERSION) $(DESTDIR)$(prefix)/include/libUseful-5
+	-$(LN) -s -r -f $(DESTDIR)$(prefix)/include/libUseful-$(VERSION) $(DESTDIR)$(prefix)/include/libUseful-5
 	-mkdir -p $(DESTDIR)$(prefix)/etc
 	cp *.conf $(DESTDIR)$(prefix)/etc
 
 
-test: libUseful.so
+test: libUseful.$(SONAME_SUFFIX)
 	-echo "No tests written yet"

--- a/Process.c
+++ b/Process.c
@@ -29,7 +29,12 @@
 
 /*This is code to change the command-line of a program as visible in ps */
 
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
 extern char **environ;
+#endif
 static char *TitleBuffer=NULL;
 static int TitleLen=0;
 

--- a/Socket.c
+++ b/Socket.c
@@ -19,6 +19,11 @@
 #include <linux/netfilter_ipv4.h>
 #endif
 
+#ifndef SOCK_NONBLOCK
+#include <fcntl.h>
+#define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
 
 
 static void SocketParseConfigFlags(const char *Config, TSockSettings *Settings)

--- a/Socket.h
+++ b/Socket.h
@@ -53,18 +53,26 @@ extern "C" {
 
 
 #ifndef HAVE_HTONLL
+#ifdef __APPLE__
+# define htonll(x) OSSwapHostToBigInt64(x)
+#else
 #if __BIG_ENDIAN__
 # define htonll(x) (x)
 #else
 # define htonll(x) ( ( (uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32) )
 #endif
 #endif
+#endif
 
 #ifndef HAVE_NTOHLL
+#ifdef __APPLE__
+# define ntohll(x) OSSwapBigToHostInt64(x)
+#else
 #if __BIG_ENDIAN__
 # define ntohll(x) (x)
 #else
 # define ntohll(x) ( ( (uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32) )
+#endif
 #endif
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,11 +54,11 @@ if test "$cf_use_soname" != "no"
 then
   if test "$GCC" = "yes"
   then
-        AC_SUBST([SONAME_FLAGS], ['-Wl,-soname,${SONAME}'])
+        AC_SUBST([SONAME_FLAGS], ['-Wl,${LINKER_SONAME_OPTION},${SONAME}'])
   else
       if test "$cf_use_soname" = "yes"
       then
-        AC_SUBST([SONAME_FLAGS], ['-Wl,-soname,${SONAME}'])
+        AC_SUBST([SONAME_FLAGS], ['-Wl,${LINKER_SONAME_OPTION},${SONAME}'])
       fi
   fi
 fi

--- a/includes.h
+++ b/includes.h
@@ -33,6 +33,9 @@ Copyright (c) 2015 Colum Paget <colums.projects@googlemail.com>
 #include <grp.h>  //for gid_t
 #include <math.h> //for math defines like PI
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#endif
 
 
 #include "defines.h"


### PR DESCRIPTION
@ColumPaget Okay, this fixes the build on macOS. Verified on 14.7 arm64 and 10.6 powerpc.

P. S. I have added a line setting `LN`, since `-r` flag is a linuxism and does not work with macOS’s native `ln`. So to make it work I change it to `LN = gln` and use `coreutils`. The default behavior is unchanged.