### PR TITLE
Entropy.c: fix HAVE_SYS_RANDOM macro

### DIFF
--- a/Entropy.c
+++ b/Entropy.c
@@ -3,7 +3,7 @@
 #include "Hash.h"
 #include <sys/utsname.h>
 
-#ifdef HAVE_SYS_RANDOM_H
+#ifdef HAVE_SYS_RANDOM
 #include <sys/random.h>
 #endif
 


### PR DESCRIPTION
`configure` defines `HAVE_SYS_RANDOM`, not `HAVE_SYS_RANDOM_H`.

```
/usr/bin/clang -L/opt/local/libexec/openssl3/lib -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -arch arm64  -pipe -I/opt/local/libexec/openssl3/include -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -arch arm64  -Wl,-dylib_install_name,libUseful.5.dylib -fPIC -DPACKAGE_NAME=\"libUseful\" -DPACKAGE_TARNAME=\"libuseful\" -DPACKAGE_VERSION=\"5.50\" -DPACKAGE_STRING=\"libUseful\ 5.50\" -DPACKAGE_BUGREPORT=\"colums.projects@gmail.com\" -DPACKAGE_URL=\"\" -DHAVE_PTSNAME_R=1 -DHAVE_INITGROUPS=1 -DHAVE_POLL=1 -DHAVE_MLOCK=1 -DHAVE_MLOCKALL=1 -DHAVE_MUNLOCKALL=1 -DHAVE_MADVISE=1 -DHAVE_MKOSTEMP=1 -DHAVE_MOUNT=1 -DHAVE_GETENTROPY=1 -DHAVE_GETLOADAVG=1 -DHAVE_SYSCONF=1 -DHAVE_GETPAGESIZE=1 -DHAVE_PTSNAME_R=1 -DHAVE_INITGROUPS=1 -DHAVE_POLL=1 -DHAVE_MLOCK=1 -DHAVE_MLOCKALL=1 -DHAVE_MUNLOCKALL=1 -DHAVE_MADVISE=1 -DHAVE_MKOSTEMP=1 -DHAVE_MOUNT=1 -DHAVE_GETENTROPY=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_SYS_RANDOM=1 -DUSE_INET6=1 -DHAVE_LIBC=1 -DHAVE_XATTR=1 -DUSE_CRC32=1 -DUSE_MD5=1 -DUSE_SHA1=1 -DUSE_SHA2=1 -DUSE_WHIRL=1 -DUSE_JH=1 -DHAVE_LIBCRYPTO=1 -DHAVE_LIBSSL=1 -DHAVE_EVP_MD_CTX_NEW=1 -DHAVE_EVP_MD_CTX_FREE=1 -DHAVE_X509_CHECK_HOST=1 -DHAVE_EVP_CIPHER_FETCH=1 -DHAVE_DECL_OPENSSL_ADD_ALL_ALGORITHMS=1 -DHAVE_OPENSSL_ADD_ALL_ALGORITHMS=1 -DHAVE_DECL_SSL_SET_TLSEXT_HOST_NAME=1 -DHAVE_SSL_SET_TLSEXT_HOST_NAME=1 -DHAVE_LIBZ=1 -DVERSION=\"5.50\" -DSYSCONFDIR=\"/opt/local/etc/libUseful\" -c OTP.c
Entropy.c:22:16: error: call to undeclared function 'getentropy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        result=getentropy(RandomBytes+len, chunk);
               ^
```